### PR TITLE
Ensure that TokenCooccurrenceVectorizer doesn't ever return a sparse …

### DIFF
--- a/vectorizers/_vectorizers.py
+++ b/vectorizers/_vectorizers.py
@@ -830,6 +830,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
             kernel_args=self.kernel_args,
             window_orientation=self.window_orientation,
         )
+        self.cooccurrences_.eliminate_zeros()
 
         self.metric_ = distances.sparse_hellinger
 


### PR DESCRIPTION
…matrix with zeros.  Those can cause no end of problems downstream.