### PR TITLE
Refactored kernels and windows

### DIFF
--- a/vectorizers/_vectorizers.py
+++ b/vectorizers/_vectorizers.py
@@ -36,6 +36,8 @@ from .utils import (
 )
 import vectorizers.distances as distances
 
+from ._window_kernels import _KERNEL_FUNCTIONS, _WINDOW_FUNCTIONS
+
 
 def construct_token_dictionary_and_frequency(token_sequence, token_dictionary=None):
     """Construct a dictionary mapping tokens to indices and a table of token
@@ -269,15 +271,7 @@ def preprocess_token_sequences(
         )
         for sequence in token_sequences
     ]
-    """
-    result_sequences = []
-    for sequence in token_sequences:
-        result_sequence = np.array(
-            [token_dictionary[token] for token in sequence if token in token_dictionary]
-        )
-        if len(result_sequence) > 0:
-            result_sequences.append(result_sequence)
-    """
+
     return (
         result_sequences,
         token_dictionary,
@@ -285,53 +279,6 @@ def preprocess_token_sequences(
         token_frequencies,
         excluded_tokens,
     )
-
-
-@numba.njit(nogil=True)
-def information_window(token_sequence, desired_entropy, token_frequency):
-    result = []
-
-    for i in range(len(token_sequence)):
-        counter = 0
-        current_entropy = 0.0
-
-        for j in range(i + 1, len(token_sequence)):
-            current_entropy -= np.log(token_frequency[int(token_sequence[j])])
-            counter += 1
-            if current_entropy >= desired_entropy:
-                break
-
-        result.append(token_sequence[i + 1 : i + 1 + counter])
-
-    return result
-
-
-@numba.njit(nogil=True)
-def fixed_window(token_sequence, window_size):
-    result = []
-
-    for i in range(len(token_sequence)):
-        result.append(token_sequence[i + 1 : i + window_size + 1])
-
-    return result
-
-
-@numba.njit(nogil=True)
-def flat_kernel(window):
-    return np.ones(len(window), dtype=np.float32)
-
-
-@numba.njit(nogil=True)
-def triangle_kernel(window, window_size):
-    start = max(window_size, len(window))
-    stop = window_size - len(window)
-    return np.arange(start, stop, -1).astype(np.float32)
-
-
-@numba.njit(nogil=True)
-def harmonic_kernel(window):
-    result = np.arange(1, len(window) + 1).astype(np.float32)
-    return 1.0 / result
 
 
 @numba.njit(nogil=True)
@@ -517,10 +464,10 @@ def sequence_skip_grams(
 def token_cooccurence_matrix(
     token_sequences,
     n_unique_tokens,
-    window_function=fixed_window,
-    kernel_function=flat_kernel,
-    window_args=(5,),
-    kernel_args=(),
+    window_function,
+    kernel_function,
+    window_args,
+    kernel_args,
     window_orientation="symmetric",
 ):
     """Generate a matrix of (weighted) counts of co-occurrences of tokens within
@@ -735,17 +682,20 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
         A set of tokens that should be ignored entirely. If None then no tokens will
         be ignored in this fashion.
 
-    window_function: numba.jitted callable (optional, default=fixed_window)
-        A function producing a sequence of windows given a source sequence
+    excluded_regex: str or None (optional, default=None)
+        The regular expression by which tokens are ignored if re.fullmatch returns True.
 
-    kernel_function: numba.jitted callable (optional, default=flat_kernel)
-        A function producing weights given a window of tokens
+    window_function: numba.jitted callable or str (optional, default='fixed')
+        A function producing a sequence of windows given a source sequence and a window_radius and term frequencies.
+        The string options are ['fixed', 'information'] for using pre-defined functions.
 
-    window_args: tuple (optional, default=(5,)
-        Arguments to pass through to the window function
+    kernel_function: numba.jitted callable or str (optional, default='flat')
+        A function producing weights given a window of tokens and a window_radius.
+        The string options are ['flat', 'triangular', 'harmonic'] for using pre-defined functions.
 
-    kernel_args: tuple (optional, default=())
-        Arguments to pass through to the kernel function
+    window_radius: int (optional, default=5)
+        Argument to pass through to the window function.  Outside of boundary cases, this is the expected width
+        of the (directed) windows produced by the window function.
 
     token_dictionary: dictionary or None (optional, default=None)
         A dictionary mapping tokens to indices
@@ -767,10 +717,9 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
         max_frequency=None,
         ignored_tokens=None,
         excluded_token_regex=None,
-        window_function=fixed_window,
-        kernel_function=flat_kernel,
-        window_args=(5,),
-        kernel_args=(),
+        window_function="fixed",
+        kernel_function="flat",
+        window_radius=5,
         window_orientation="symmetric",
         validate_data=True,
     ):
@@ -784,8 +733,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
 
         self.window_function = window_function
         self.kernel_function = kernel_function
-        self.window_args = window_args
-        self.kernel_args = kernel_args
+        self.window_radius = window_radius
 
         self.window_orientation = window_orientation
         self.validate_data = validate_data
@@ -800,7 +748,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
             token_sequences,
             self.column_label_dictionary_,
             self.column_index_dictionary_,
-            self.token_frequencies_,
+            self._token_frequencies_,
             self.excluded_tokens_,
         ) = preprocess_token_sequences(
             X,
@@ -814,18 +762,40 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
             excluded_token_regex=self.excluded_token_regex,
         )
 
-        if self.window_function is information_window:
-            window_args = (*self.window_args, self.token_frequencies_)
+        if callable(self.kernel_function):
+            self._kernel_function = self.kernel_function
+        elif self.kernel_function in _KERNEL_FUNCTIONS:
+            self._kernel_function = _KERNEL_FUNCTIONS[self.kernel_function]
         else:
-            window_args = self.window_args
+            raise ValueError(
+                f"Unrecognized kernel_function; should be callable or one of {_KERNEL_FUNCTIONS.keys()}"
+            )
+
+        if callable(self.window_function):
+            self._window_function = self.window_function
+        elif self.window_function in _WINDOW_FUNCTIONS:
+            self._window_function = _WINDOW_FUNCTIONS[self.window_function]
+        else:
+            raise ValueError(
+                f"Unrecognized window_function; should be callable or one of {_WINDOW_FUNCTIONS.keys()}"
+            )
+
+            ## Adjust the window size for the info window
+        if self.window_function == "information":
+            entropy = np.dot(
+                self._token_frequencies_, np.log2(self._token_frequencies_)
+            )
+            self._window_size = self.window_radius * entropy
+        else:
+            self._window_size = self.window_radius
 
         self.cooccurrences_ = token_cooccurence_matrix(
             token_sequences,
             len(self.column_label_dictionary_),
-            window_function=self.window_function,
-            kernel_function=self.kernel_function,
-            window_args=window_args,
-            kernel_args=self.kernel_args,
+            window_function=self._window_function,
+            kernel_function=self._kernel_function,
+            window_args=(self._window_size, self._token_frequencies_),
+            kernel_args=(self.window_radius,),
             window_orientation=self.window_orientation,
         )
         self.cooccurrences_.eliminate_zeros()
@@ -1156,6 +1126,68 @@ class CyclicHistogramVectorizer(BaseEstimator, TransformerMixin):
 
 
 class SkipgramVectorizer(BaseEstimator, TransformerMixin):
+    """Given a sequence, or list of sequences of tokens, produce a
+    kernel weighted count matrix of ordered pairs of tokens occurring in a window.
+    If passed a single sequence of tokens it  will use windows to determine co-occurrence.
+    If passed a list of sequences of tokens it will use windows within each sequence in the list
+    -- with windows not extending beyond the boundaries imposed by the individual sequences in the list.
+
+    Parameters
+    ----------
+    token_dictionary: dictionary or None (optional, default=None)
+        A fixed ditionary mapping tokens to indices, or None if the dictionary
+        should be learned from the training data.
+
+    min_occurrences: int or None (optional, default=None)
+        The minimal number of occurrences of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by min_frequency.
+
+    max_occurrences int or None (optional, default=None)
+        The maximal number of occurrences of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by max_frequency.
+
+    min_frequency: float or None (optional, default=None)
+        The minimal frequency of occurrence of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by min_occurences.
+
+    max_frequency: float or None (optional, default=None)
+        The maximal frequency of occurrence of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by max_occurences.
+
+    ignored_tokens: set or None (optional, default=None)
+        A set of tokens that should be ignored entirely. If None then no tokens will
+        be ignored in this fashion.
+
+    excluded_regex: str or None (optional, default=None)
+        The regular expression by which tokens are ignored if re.fullmatch returns True.
+
+    window_function: numba.jitted callable or str (optional, default='fixed')
+        A function producing a sequence of windows given a source sequence and a window_radius and term frequencies.
+        The string options are ['fixed', 'information'] for using pre-defined functions.
+
+    kernel_function: numba.jitted callable or str (optional, default='flat')
+        A function producing weights given a window of tokens and a window_radius.
+        The string options are ['flat', 'triangular', 'harmonic'] for using pre-defined functions.
+
+    window_radius: int (optional, default=5)
+        Argument to pass through to the window function.  Outside of boundary cases, this is the expected width
+        of the (directed) windows produced by the window function.
+
+    token_dictionary: dictionary or None (optional, default=None)
+        A dictionary mapping tokens to indices
+
+    window_orientation: string (['before', 'after', 'symmetric'])
+        The orientation of the cooccurence window.  Whether to return all the tokens that
+        occurred within a window before, after or on either side.
+
+    validate_data: bool (optional, default=True)
+        Check whether the data is valid (e.g. of homogeneous token type).
+    """
+
     def __init__(
         self,
         token_dictionary=None,
@@ -1165,10 +1197,9 @@ class SkipgramVectorizer(BaseEstimator, TransformerMixin):
         max_frequency=None,
         ignored_tokens=None,
         excluded_token_regex=None,
-        window_function=fixed_window,
-        kernel_function=flat_kernel,
-        window_args=(5,),
-        kernel_args=(),
+        window_function="fixed",
+        kernel_function="flat",
+        window_radius=5,
         validate_data=True,
     ):
         self.token_dictionary = token_dictionary
@@ -1181,8 +1212,7 @@ class SkipgramVectorizer(BaseEstimator, TransformerMixin):
 
         self.window_function = window_function
         self.kernel_function = kernel_function
-        self.window_args = window_args
-        self.kernel_args = kernel_args
+        self.window_radius = window_radius
         self.validate_data = validate_data
 
     def fit(self, X, y=None, **fit_params):
@@ -1211,12 +1241,42 @@ class SkipgramVectorizer(BaseEstimator, TransformerMixin):
 
         n_unique_tokens = len(self._token_dictionary_)
 
+        # Set the kernel and window functions
+
+        if callable(self.kernel_function):
+            self._kernel_function = self.kernel_function
+        elif self.kernel_function in _KERNEL_FUNCTIONS:
+            self._kernel_function = _KERNEL_FUNCTIONS[self.kernel_function]
+        else:
+            raise ValueError(
+                f"Unrecognized kernel_function; should be callable or one of {_KERNEL_FUNCTIONS.keys()}"
+            )
+
+        if callable(self.window_function):
+            self._window_function = self.window_function
+        elif self.window_function in _WINDOW_FUNCTIONS:
+            self._window_function = _WINDOW_FUNCTIONS[self.window_function]
+        else:
+            raise ValueError(
+                f"Unrecognized window_function; should be callable or one of {_WINDOW_FUNCTIONS.keys()}"
+            )
+
+        #  Adjust the window size for the info window
+        if self.window_function == "information":
+            entropy = np.dot(
+                self._token_frequencies_, np.log2(self._token_frequencies_)
+            )
+            self._window_size = self.window_radius * entropy
+        else:
+            self._window_size = self.window_radius
+
+        # Build the matrix
         row, col, data = skip_grams_matrix_coo_data(
             token_sequences,
-            self.window_function,
-            self.kernel_function,
-            self.window_args,
-            self.kernel_args,
+            self._window_function,
+            self._kernel_function,
+            (self._window_size, self._token_frequencies_),
+            tuple([self.window_radius]),
             self._token_dictionary_,
         )
 
@@ -1259,10 +1319,10 @@ class SkipgramVectorizer(BaseEstimator, TransformerMixin):
 
         row, col, data = skip_grams_matrix_coo_data(
             token_sequences,
-            self.window_function,
-            self.kernel_function,
-            self.window_args,
-            self.kernel_args,
+            self._window_function,
+            self._kernel_function,
+            (self._window_size, self._token_frequencies_),
+            tuple([self.window_radius]),
             self._token_dictionary_,
         )
 
@@ -1273,6 +1333,61 @@ class SkipgramVectorizer(BaseEstimator, TransformerMixin):
 
 
 class NgramVectorizer(BaseEstimator, TransformerMixin):
+    """Given a sequence, or list of sequences of tokens, produce a
+    count matrix of n-grams of successive tokens.  This either produces n-grams for a fixed size or all n-grams
+    up to a fixed size.
+
+    Parameters
+    ----------
+    ngram_size: int (default = 1)
+        The size of the ngrams to count.
+
+    ngram_behaviour: string (optional, default="exact")
+        The n-gram behaviour. Should be one of ["exact", "subgrams"] to produce either fixed size ngram_size
+        or all ngrams of size upto (and including) ngram_size.
+
+    ngram_dictionary: dictionary or None (optional, default=None)
+        A fixed dictionary mapping tokens to indices, or None if the dictionary
+        should be learned from the training data.
+
+    token_dictionary: dictionary or None (optional, default=None)
+        A fixed dictionary mapping tokens to indices, or None if the dictionary
+        should be learned from the training data.
+
+    min_occurrences: int or None (optional, default=None)
+        The minimal number of occurrences of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by min_frequency.
+
+    max_occurrences int or None (optional, default=None)
+        The maximal number of occurrences of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by max_frequency.
+
+    min_frequency: float or None (optional, default=None)
+        The minimal frequency of occurrence of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by min_occurences.
+
+    max_frequency: float or None (optional, default=None)
+        The maximal frequency of occurrence of a token for it to be considered and
+        counted. If None then there is no constraint, or the constraint is
+        determined by max_occurences.
+
+    ignored_tokens: set or None (optional, default=None)
+        A set of tokens that should be ignored entirely. If None then no tokens will
+        be ignored in this fashion.
+
+    excluded_regex: str or None (optional, default=None)
+        The regular expression by which tokens are ignored if re.fullmatch returns True.
+
+    token_dictionary: dictionary or None (optional, default=None)
+        A dictionary mapping tokens to indices
+
+    validate_data: bool (optional, default=True)
+        Check whether the data is valid (e.g. of homogeneous token type).
+    """
+
     def __init__(
         self,
         ngram_size=1,

--- a/vectorizers/_window_kernels.py
+++ b/vectorizers/_window_kernels.py
@@ -1,0 +1,57 @@
+import numpy as np
+import numba
+
+
+@numba.njit(nogil=True)
+def information_window(token_sequence, window_size, token_frequency):
+    result = []
+
+    for i in range(len(token_sequence)):
+        counter = 0
+        current_entropy = 0.0
+
+        for j in range(i + 1, len(token_sequence)):
+            current_entropy -= np.log(token_frequency[int(token_sequence[j])])
+            counter += 1
+            if current_entropy >= window_size:
+                break
+
+        result.append(token_sequence[i + 1 : i + 1 + counter])
+
+    return result
+
+
+@numba.njit(nogil=True)
+def fixed_window(token_sequence, window_size, token_frequency):
+    result = []
+    for i in range(len(token_sequence)):
+        result.append(token_sequence[i + 1 : i + window_size + 1])
+
+    return result
+
+
+@numba.njit(nogil=True)
+def flat_kernel(window, window_size):
+    return np.ones(len(window), dtype=np.float32)
+
+
+@numba.njit(nogil=True)
+def triangle_kernel(window, window_size):
+    start = max(window_size, len(window))
+    stop = window_size - len(window)
+    return np.arange(start, stop, -1).astype(np.float32)
+
+
+@numba.njit(nogil=True)
+def harmonic_kernel(window, window_size):
+    result = np.arange(1, len(window) + 1).astype(np.float32)
+    return 1.0 / result
+
+
+_WINDOW_FUNCTIONS = {"information": information_window, "fixed": fixed_window}
+
+_KERNEL_FUNCTIONS = {
+    "flat": flat_kernel,
+    "harmonic": harmonic_kernel,
+    "triangular": triangle_kernel,
+}

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -18,14 +18,15 @@ from vectorizers import Wasserstein1DHistogramTransformer
 from vectorizers.distances import kantorovich1d
 
 from vectorizers._vectorizers import (
+    ngrams_of,
+    find_bin_boundaries,
+)
+from vectorizers._window_kernels import (
     harmonic_kernel,
     triangle_kernel,
     flat_kernel,
     information_window,
-    ngrams_of,
-    find_bin_boundaries,
 )
-
 
 token_data = (
     (1, 3, 1, 4, 2),
@@ -99,21 +100,21 @@ value_sequence_data = [
 
 
 def test_harmonic_kernel():
-    kernel = harmonic_kernel([0, 0, 0, 0])
+    kernel = harmonic_kernel([0, 0, 0, 0], 4.0)
     assert kernel[0] == 1.0
     assert kernel[-1] == 1.0 / 4.0
     assert kernel[1] == 1.0 / 2.0
 
 
 def test_triangle_kernel():
-    kernel = triangle_kernel([0, 0, 0, 0], 4)
+    kernel = triangle_kernel([0, 0, 0, 0], 4.0)
     assert kernel[0] == 4.0
     assert kernel[-1] == 1.0
     assert kernel[1] == 3.0
 
 
 def test_flat_kernel():
-    kernel = flat_kernel([0] * np.random.randint(2, 10))
+    kernel = flat_kernel([0] * np.random.randint(2, 10), 0.0)
     assert np.all(kernel == 1.0)
 
 
@@ -155,7 +156,7 @@ def test_token_cooccurrence_vectorizer_basic():
     result = vectorizer.fit_transform(token_data)
     assert scipy.sparse.issparse(result)
     vectorizer = TokenCooccurrenceVectorizer(
-        window_args=(1,), window_orientation="after"
+        window_radius=1, window_orientation="after"
     )
     result = vectorizer.fit_transform(token_data)
     assert result[0, 2] == 8
@@ -167,7 +168,7 @@ def test_token_cooccurrence_vectorizer_text():
     result = vectorizer.fit_transform(text_token_data)
     assert scipy.sparse.issparse(result)
     vectorizer = TokenCooccurrenceVectorizer(
-        window_args=(1,), window_orientation="after"
+        window_radius=1, window_orientation="after"
     )
     result = vectorizer.fit_transform(text_token_data)
     assert result[1, 2] == 8
@@ -179,7 +180,7 @@ def test_token_cooccurrence_vectorizer_fixed_tokens():
     result = vectorizer.fit_transform(token_data)
     assert scipy.sparse.issparse(result)
     vectorizer = TokenCooccurrenceVectorizer(
-        window_args=(1,), window_orientation="after"
+        window_radius=1, window_orientation="after"
     )
     result = vectorizer.fit_transform(token_data)
     assert result[0, 2] == 8
@@ -197,7 +198,7 @@ def test_token_cooccurrence_vectorizer_min_occur():
     result = vectorizer.fit_transform(token_data)
     assert scipy.sparse.issparse(result)
     vectorizer = TokenCooccurrenceVectorizer(
-        window_args=(1,), window_orientation="after"
+        window_radius=1, window_orientation="after"
     )
     result = vectorizer.fit_transform(token_data)
     assert result[0, 2] == 8
@@ -209,7 +210,7 @@ def test_token_cooccurrence_vectorizer_max_freq():
     result = vectorizer.fit_transform(token_data)
     assert scipy.sparse.issparse(result)
     vectorizer = TokenCooccurrenceVectorizer(
-        window_args=(1,), window_orientation="after"
+        window_radius=1, window_orientation="after"
     )
     result = vectorizer.fit_transform(token_data)
     assert result[0, 2] == 8
@@ -217,11 +218,11 @@ def test_token_cooccurrence_vectorizer_max_freq():
 
 
 def test_token_cooccurrence_vectorizer_info_window():
-    vectorizer = TokenCooccurrenceVectorizer(window_function=information_window)
+    vectorizer = TokenCooccurrenceVectorizer(window_function="information")
     result = vectorizer.fit_transform(token_data)
     assert scipy.sparse.issparse(result)
     vectorizer = TokenCooccurrenceVectorizer(
-        window_args=(1,), window_orientation="after"
+        window_radius=1, window_orientation="after"
     )
     result = vectorizer.fit_transform(token_data)
     assert result[0, 2] == 8


### PR DESCRIPTION
SkipGramVectorizer and TokenCoocurrenceVectorizer now allow for string named kernel and window functions which were moved into a new seperate file.  Instead of args, the classes now simply take window_radius.