### PR TITLE
Fixes for spherical vectors (e.g. word vectors)

### DIFF
--- a/vectorizers/__init__.py
+++ b/vectorizers/__init__.py
@@ -8,6 +8,7 @@ from ._vectorizers import ProductDistributionVectorizer
 from ._vectorizers import Wasserstein1DHistogramTransformer
 from ._vectorizers import SequentialDifferenceTransformer
 from ._vectorizers import LabelledTreeCooccurrenceVectorizer
+from .linear_optimal_transport import WassersteinVectorizer
 
 from .utils import cast_tokens_to_strings
 
@@ -24,5 +25,6 @@ __all__ = [
     "Wasserstein1DHistogramTransformer",
     "SequentialDifferenceTransformer",
     "LabelledTreeCooccurrenceVectorizer",
+    "WassersteinVectorizer",
     "__version__",
 ]

--- a/vectorizers/linear_optimal_transport.py
+++ b/vectorizers/linear_optimal_transport.py
@@ -491,6 +491,7 @@ def lot_vectors_sparse(
     random_state=None,
     max_distribution_size=256,
     block_size=16384,
+    n_svd_iter=10,
 ):
     """Given distributions over a metric space produce a compressed array
     of linear optimal transport vectors, one for each distribution, and
@@ -547,6 +548,10 @@ def lot_vectors_sparse(
         learn less well in more, smaller, batches). Setting this too large can
         cause the algorithm to exceed memory.
 
+    n_svd_iter: int (optional, default=10)
+        How many iterations of randomized SVD to run to get compressed vectors. More
+        iterations will produce better results at greater computational cost.
+
     Returns
     -------
     lot_vectors: ndarray
@@ -579,7 +584,7 @@ def lot_vectors_sparse(
         u, singular_values, v = randomized_svd(
             lot_vectors,
             n_components=n_components,
-            n_iter=10,
+            n_iter=n_svd_iter,
             random_state=random_state,
         )
         result, components = svd_flip(u, v)
@@ -623,7 +628,7 @@ def lot_vectors_sparse(
         u, singular_values, v = randomized_svd(
             block_to_learn,
             n_components=n_components,
-            n_iter=10,
+            n_iter=n_svd_iter,
             random_state=random_state,
         )
         u, components = svd_flip(u, v)
@@ -654,6 +659,7 @@ def lot_vectors_dense(
     random_state=None,
     max_distribution_size=256,
     block_size=16384,
+    n_svd_iter=10,
 ):
     """Given distributions over a metric space produce a compressed array
     of linear optimal transport vectors, one for each distribution, and
@@ -707,6 +713,10 @@ def lot_vectors_dense(
         learn less well in more, smaller, batches). Setting this too large can
         cause the algorithm to exceed memory.
 
+    n_svd_iter: int (optional, default=10)
+        How many iterations of randomized SVD to run to get compressed vectors. More
+        iterations will produce better results at greater computational cost.
+
     Returns
     -------
     lot_vectors: ndarray
@@ -735,7 +745,7 @@ def lot_vectors_dense(
         u, singular_values, v = randomized_svd(
             lot_vectors,
             n_components=n_components,
-            n_iter=10,
+            n_iter=n_svd_iter,
             random_state=random_state,
         )
         result, components = svd_flip(u, v)
@@ -778,7 +788,7 @@ def lot_vectors_dense(
         u, singular_values, v = randomized_svd(
             block_to_learn,
             n_components=n_components,
-            n_iter=10,
+            n_iter=n_svd_iter,
             random_state=random_state,
         )
         u, components = svd_flip(u, v)
@@ -850,6 +860,10 @@ class WassersteinVectorizer(BaseEstimator, TransformerMixin):
         distributions over more vectors will be truncated back
         to this value for faster performance.
 
+    n_svd_iter: int (optional, default=10)
+        How many iterations of randomized SVD to run to get compressed vectors. More
+        iterations will produce better results at greater computational cost.
+
     random_state: numpy.random.random_state or int or None (optional, default=None)
         A random state to use. A fixed integer seed can be used for reproducibility.
     """
@@ -862,6 +876,7 @@ class WassersteinVectorizer(BaseEstimator, TransformerMixin):
         metric="cosine",
         memory_size="2G",
         max_distribution_size=256,
+        n_svd_iter=10,
         random_state=None,
     ):
         self.n_components = n_components
@@ -870,6 +885,7 @@ class WassersteinVectorizer(BaseEstimator, TransformerMixin):
         self.metric = metric
         self.memory_size = memory_size
         self.max_distribution_size = max_distribution_size
+        self.n_svd_iter = n_svd_iter
         self.random_state = random_state
 
     def _get_metric(self):
@@ -975,9 +991,10 @@ class WassersteinVectorizer(BaseEstimator, TransformerMixin):
                 self.reference_distribution_,
                 self.n_components,
                 metric,
-                random_state,
-                self.max_distribution_size,
-                block_size,
+                random_state=random_state,
+                max_distribution_size=self.max_distribution_size,
+                block_size=block_size,
+                n_svd_iter=self.n_svd_iter,
             )
 
         elif type(X) in (list, tuple, numba.typed.List):
@@ -1037,9 +1054,10 @@ class WassersteinVectorizer(BaseEstimator, TransformerMixin):
                 self.reference_distribution_,
                 self.n_components,
                 metric,
-                random_state,
-                self.max_distribution_size,
-                block_size,
+                random_state=random_state,
+                max_distribution_size=self.max_distribution_size,
+                block_size=block_size,
+                n_svd_iter=self.n_svd_iter,
             )
         else:
             raise ValueError(

--- a/vectorizers/linear_optimal_transport.py
+++ b/vectorizers/linear_optimal_transport.py
@@ -382,6 +382,12 @@ def lot_vectors_sparse_internal(
 
                 result[i] = transport_vectors.flatten()
 
+    # Help the SVD preserve spherical data by sqrt entries
+    if spherical_vectors:
+        for i in range(result.shape[0]):
+            for j in range(result.shape[1]):
+                result[i, j] = np.sign(result[i,j]) * np.sqrt(np.abs(result[i, j]))
+
     return result
 
 
@@ -487,6 +493,12 @@ def lot_vectors_dense_internal(
                     transport_vectors = tangent_vectors * scaling
 
                 result[i] = transport_vectors.flatten()
+
+    # Help the SVD preserve spherical data by sqrt entries
+    if spherical_vectors:
+        for i in range(result.shape[0]):
+            for j in range(result.shape[1]):
+                result[i, j] = np.sign(result[i,j]) * np.sqrt(np.abs(result[i, j]))
 
     return result
 

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -899,14 +899,14 @@ def test_wasserstein_vectorizer_basic():
     vectorizer = WassersteinVectorizer(random_state=42)
     result = vectorizer.fit_transform(distributions_data, vectors=vectors_data)
     transform_result = vectorizer.transform(distributions_data, vectors=vectors_data)
-    assert np.allclose(result, transform_result)
+    assert np.allclose(result, transform_result, rtol=1e-3, atol=1e-6)
 
 
 def test_wasserstein_vectorizer_blockwise():
     vectorizer = WassersteinVectorizer(random_state=42, memory_size="50k")
     result = vectorizer.fit_transform(distributions_data, vectors=vectors_data)
     transform_result = vectorizer.transform(distributions_data, vectors=vectors_data)
-    assert np.allclose(result, transform_result)
+    assert np.allclose(result, transform_result, rtol=1e-3, atol=1e-6)
 
 
 def test_wasserstein_vectorizer_list_based():
@@ -916,7 +916,7 @@ def test_wasserstein_vectorizer_list_based():
     vectorizer = WassersteinVectorizer(random_state=42)
     result = vectorizer.fit_transform(distributions, vectors=vectors)
     transform_result = vectorizer.transform(distributions, vectors=vectors)
-    assert np.allclose(result, transform_result)
+    assert np.allclose(result, transform_result, rtol=1e-3, atol=1e-6)
 
 
 def test_wasserstein_vectorizer_list_based_blockwise():
@@ -926,7 +926,7 @@ def test_wasserstein_vectorizer_list_based_blockwise():
     vectorizer = WassersteinVectorizer(random_state=42, memory_size="50k")
     result = vectorizer.fit_transform(distributions, vectors=vectors)
     transform_result = vectorizer.transform(distributions, vectors=vectors)
-    assert np.allclose(result, transform_result)
+    assert np.allclose(result, transform_result, rtol=1e-3, atol=1e-6)
 
 
 def test_wasserstein_vectorizer_list_compared_to_sparse():
@@ -944,7 +944,7 @@ def test_wasserstein_vectorizer_list_compared_to_sparse():
         reference_distribution=vectorizer_sparse.reference_distribution_,
         reference_vectors=vectorizer_sparse.reference_vectors_,
     )
-    assert np.allclose(result_sparse, result_list)
+    assert np.allclose(result_sparse, result_list, rtol=1e-3, atol=1e-6)
 
 
 def test_node_removal():


### PR DESCRIPTION
There were some catches in the numba handling of spherical vectors which I fixed up, plus a few other minor fixes along the way, and I added a square root for spherical vectors/l2 normalized vectors prior to the SVD for the same reason that we have a fourth root in the word vectors. It does improve performance on downstream tasks in the examples I tried.