### PR TITLE
BayesEM and Dynamic COO memory

### DIFF
--- a/vectorizers/coo_utils.py
+++ b/vectorizers/coo_utils.py
@@ -7,6 +7,7 @@ CooArray = namedtuple("CooArray", ["row", "col", "val", "key", "ind", "min", "de
 COO_QUICKSORT_LIMIT = 1 << 16
 COO_MEM_MULTIPLIER = 2.0
 
+
 @numba.njit(nogil=True)
 def set_array_size(token_sequences, window_array):
     tot_len = np.zeros(window_array.shape[0]).astype(np.float64)
@@ -18,6 +19,7 @@ def set_array_size(token_sequences, window_array):
         ).T  # NOTE: numba only does dot products with floats
     tot_len[tot_len <= COO_QUICKSORT_LIMIT] = COO_QUICKSORT_LIMIT + 1
     return tot_len.astype(np.int64)
+
 
 @numba.njit(nogil=True)
 def merge_sum_duplicates(coo):
@@ -156,27 +158,27 @@ def coo_increase_mem(coo):
     temp = coo.row
     new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
     new_row = np.zeros(new_size, dtype=np.int32)
-    new_row[:temp.shape[0]] = temp
+    new_row[: temp.shape[0]] = temp
 
     temp = coo.col
     new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
     new_col = np.zeros(new_size, dtype=np.int32)
-    new_col[:temp.shape[0]] = temp
+    new_col[: temp.shape[0]] = temp
 
     temp = coo.val
     new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
     new_val = np.zeros(new_size, dtype=np.float32)
-    new_val[:temp.shape[0]] = temp
+    new_val[: temp.shape[0]] = temp
 
     temp = coo.key
     new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
     new_key = np.zeros(new_size, dtype=np.int64)
-    new_key[:temp.shape[0]] = temp
+    new_key[: temp.shape[0]] = temp
 
     temp = coo.min
     new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
     new_min = np.zeros(new_size, dtype=np.int64)
-    new_min[:temp.shape[0]] = temp
+    new_min[: temp.shape[0]] = temp
 
     coo = CooArray(
         new_row,
@@ -189,7 +191,6 @@ def coo_increase_mem(coo):
     )
 
     return coo
-
 
 
 @numba.njit(nogil=True)
@@ -215,6 +216,7 @@ def coo_append(coo, tup):
                 coo = coo_increase_mem(coo)
 
     return coo
+
 
 @numba.njit(nogil=True)
 def sum_coo_entries(seq):

--- a/vectorizers/coo_utils.py
+++ b/vectorizers/coo_utils.py
@@ -5,7 +5,19 @@ from collections import namedtuple
 CooArray = namedtuple("CooArray", ["row", "col", "val", "key", "ind", "min", "depth"])
 
 COO_QUICKSORT_LIMIT = 1 << 16
+COO_MEM_MULTIPLIER = 2.0
 
+@numba.njit(nogil=True)
+def set_array_size(token_sequences, window_array):
+    tot_len = np.zeros(window_array.shape[0]).astype(np.float64)
+    window_array = window_array.astype(np.float64)
+    for seq in token_sequences:
+        counts = np.bincount(seq, minlength=window_array.shape[1]).astype(np.float64)
+        tot_len += np.dot(
+            window_array, counts
+        ).T  # NOTE: numba only does dot products with floats
+    tot_len[tot_len <= COO_QUICKSORT_LIMIT] = COO_QUICKSORT_LIMIT + 1
+    return tot_len.astype(np.int64)
 
 @numba.njit(nogil=True)
 def merge_sum_duplicates(coo):
@@ -139,6 +151,48 @@ def coo_sum_duplicates(coo, kind):
 
 
 @numba.njit(nogil=True)
+def coo_increase_mem(coo):
+
+    temp = coo.row
+    new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
+    new_row = np.zeros(new_size, dtype=np.int32)
+    new_row[:temp.shape[0]] = temp
+
+    temp = coo.col
+    new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
+    new_col = np.zeros(new_size, dtype=np.int32)
+    new_col[:temp.shape[0]] = temp
+
+    temp = coo.val
+    new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
+    new_val = np.zeros(new_size, dtype=np.float32)
+    new_val[:temp.shape[0]] = temp
+
+    temp = coo.key
+    new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
+    new_key = np.zeros(new_size, dtype=np.int64)
+    new_key[:temp.shape[0]] = temp
+
+    temp = coo.min
+    new_size = np.int32(np.round(COO_MEM_MULTIPLIER * temp.shape[0]))
+    new_min = np.zeros(new_size, dtype=np.int64)
+    new_min[:temp.shape[0]] = temp
+
+    coo = CooArray(
+        new_row,
+        new_col,
+        new_val,
+        new_key,
+        coo.ind,
+        new_min,
+        coo.depth,
+    )
+
+    return coo
+
+
+
+@numba.njit(nogil=True)
 def coo_append(coo, tup):
     coo.row[coo.ind[0]] = tup[0]
     coo.col[coo.ind[0]] = tup[1]
@@ -151,19 +205,16 @@ def coo_append(coo, tup):
         if (coo.key.shape[0] - np.abs(coo.min[0])) <= COO_QUICKSORT_LIMIT:
             merge_all_sum_duplicates(coo)
             if coo.ind[0] >= 0.95 * coo.key.shape[0]:
-                raise ValueError(
-                    f"The coo matrix array is over memory limit.  Increase coo_max_bytes to process data."
-                )
+                coo = coo_increase_mem(coo)
 
     if coo.ind[0] == coo.key.shape[0]:
         coo_sum_duplicates(coo, kind="quicksort")
         if (coo.key.shape[0] - np.abs(coo.min[0])) <= COO_QUICKSORT_LIMIT:
             merge_all_sum_duplicates(coo)
             if coo.ind[0] >= 0.95 * coo.key.shape[0]:
-                raise ValueError(
-                    f"The coo matrix array is over memory limit.  Increase coo_max_bytes to process data."
-                )
+                coo = coo_increase_mem(coo)
 
+    return coo
 
 @numba.njit(nogil=True)
 def sum_coo_entries(seq):

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -520,6 +520,24 @@ def test_cooccurrence_vectorizer_coo_mem():
     assert np.allclose(mat1, mat2)
 
 
+def test_cooccurrence_vectorizer_coo_mem_limit():
+    vectorizer_a = TokenCooccurrenceVectorizer(
+        window_functions="fixed",
+        n_iter=0,
+        coo_max_memory="1k",
+        normalize_windows=False,
+    )
+    vectorizer_b = TokenCooccurrenceVectorizer(
+        window_functions="fixed",
+        n_iter=0,
+        normalize_windows=False,
+    )
+    data = [[np.random.randint(0, 10) for i in range(100)]]
+    mat1 = vectorizer_a.fit_transform(data).toarray()
+    mat2 = vectorizer_b.fit_transform(data).toarray()
+    assert np.allclose(mat1, mat2)
+
+
 @pytest.mark.parametrize("skip_grams_size", [1, 2])
 def test_cooccurrence_vectorizer_em_iter(skip_grams_size):
     vectorizer_a = TokenCooccurrenceVectorizer(

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -258,6 +258,7 @@ def test_equality_of_Tree_and_Token_CooccurrenceVectorizers(
 @pytest.mark.parametrize("mask_string", [None, "[MASK]"])
 @pytest.mark.parametrize("nullify_mask", [False, True])
 @pytest.mark.parametrize("normalize_windows", [False, True])
+@pytest.mark.parametrize("normalization", ["Bayesian", "frequentist"])
 def test_equality_of_TokenCooccurrenceVectorizer(
     min_token_occurrences,
     max_document_frequency,
@@ -269,6 +270,7 @@ def test_equality_of_TokenCooccurrenceVectorizer(
     nullify_mask,
     n_iter,
     normalize_windows,
+    normalization,
 ):
     model1 = TokenCooccurrenceVectorizer(
         window_radii=[window_radius],
@@ -280,6 +282,7 @@ def test_equality_of_TokenCooccurrenceVectorizer(
         n_iter=n_iter,
         nullify_mask=nullify_mask and mask_string is not None,
         normalize_windows=normalize_windows,
+        normalization=normalization
     )
     model2 = TokenCooccurrenceVectorizer(
         window_radii=window_radius,
@@ -291,6 +294,7 @@ def test_equality_of_TokenCooccurrenceVectorizer(
         n_iter=n_iter,
         nullify_mask=nullify_mask and mask_string is not None,
         normalize_windows=normalize_windows,
+        normalization=normalization
     )
     assert np.allclose(
         model1.fit_transform(text_token_data_permutation).toarray(),
@@ -487,9 +491,9 @@ def test_token_cooccurrence_vectorizer_kernel_args():
 
 
 def test_cooccurrence_vectorizer_epsilon():
-    vectorizer_a = TokenCooccurrenceVectorizer(epsilon=0)
-    vectorizer_b = TokenCooccurrenceVectorizer(epsilon=1e-11)
-    vectorizer_c = TokenCooccurrenceVectorizer(epsilon=1)
+    vectorizer_a = TokenCooccurrenceVectorizer(epsilon=0, normalization='frequentist')
+    vectorizer_b = TokenCooccurrenceVectorizer(epsilon=1e-11, normalization='frequentist')
+    vectorizer_c = TokenCooccurrenceVectorizer(epsilon=1, normalization='frequentist')
     mat1 = normalize(
         vectorizer_a.fit_transform(token_data).toarray(), axis=0, norm="l1"
     )
@@ -522,7 +526,7 @@ def test_cooccurrence_vectorizer_em_iter(skip_grams_size):
         n_iter=0, skip_ngram_size=skip_grams_size
     )
     vectorizer_b = TokenCooccurrenceVectorizer(
-        n_iter=2, skip_ngram_size=skip_grams_size
+        n_iter=2, skip_ngram_size=skip_grams_size, normalization='frequentist'
     )
     assert (
         vectorizer_a.fit_transform(token_data).nnz
@@ -545,6 +549,7 @@ def test_cooccurrence_vectorizer_wide_iter():
         mix_weights=[1, 1],
         window_functions=["fixed", "variable"],
         window_orientations=['directional', 'directional'],
+        normalization = 'frequentist',
         n_iter=2,
     )
     assert (

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -282,7 +282,7 @@ def test_equality_of_TokenCooccurrenceVectorizer(
         n_iter=n_iter,
         nullify_mask=nullify_mask and mask_string is not None,
         normalize_windows=normalize_windows,
-        normalization=normalization
+        normalization=normalization,
     )
     model2 = TokenCooccurrenceVectorizer(
         window_radii=window_radius,
@@ -294,7 +294,7 @@ def test_equality_of_TokenCooccurrenceVectorizer(
         n_iter=n_iter,
         nullify_mask=nullify_mask and mask_string is not None,
         normalize_windows=normalize_windows,
-        normalization=normalization
+        normalization=normalization,
     )
     assert np.allclose(
         model1.fit_transform(text_token_data_permutation).toarray(),
@@ -491,9 +491,11 @@ def test_token_cooccurrence_vectorizer_kernel_args():
 
 
 def test_cooccurrence_vectorizer_epsilon():
-    vectorizer_a = TokenCooccurrenceVectorizer(epsilon=0, normalization='frequentist')
-    vectorizer_b = TokenCooccurrenceVectorizer(epsilon=1e-11, normalization='frequentist')
-    vectorizer_c = TokenCooccurrenceVectorizer(epsilon=1, normalization='frequentist')
+    vectorizer_a = TokenCooccurrenceVectorizer(epsilon=0, normalization="frequentist")
+    vectorizer_b = TokenCooccurrenceVectorizer(
+        epsilon=1e-11, normalization="frequentist"
+    )
+    vectorizer_c = TokenCooccurrenceVectorizer(epsilon=1, normalization="frequentist")
     mat1 = normalize(
         vectorizer_a.fit_transform(token_data).toarray(), axis=0, norm="l1"
     )
@@ -544,7 +546,7 @@ def test_cooccurrence_vectorizer_em_iter(skip_grams_size):
         n_iter=0, skip_ngram_size=skip_grams_size
     )
     vectorizer_b = TokenCooccurrenceVectorizer(
-        n_iter=2, skip_ngram_size=skip_grams_size, normalization='frequentist'
+        n_iter=2, skip_ngram_size=skip_grams_size, normalization="frequentist"
     )
     assert (
         vectorizer_a.fit_transform(token_data).nnz
@@ -558,7 +560,7 @@ def test_cooccurrence_vectorizer_wide_iter():
         window_radii=[1, 2],
         mix_weights=[1, 1],
         window_functions=("fixed", "variable"),
-        window_orientations=['directional', 'directional'],
+        window_orientations=["directional", "directional"],
         n_iter=0,
     )
     vectorizer_b = TokenCooccurrenceVectorizer(
@@ -566,8 +568,8 @@ def test_cooccurrence_vectorizer_wide_iter():
         window_radii=[1, 2],
         mix_weights=[1, 1],
         window_functions=["fixed", "variable"],
-        window_orientations=['directional', 'directional'],
-        normalization = 'frequentist',
+        window_orientations=["directional", "directional"],
+        normalization="frequentist",
         n_iter=2,
     )
     assert (
@@ -582,7 +584,7 @@ def test_cooccurrence_vectorizer_wide_transform():
         window_radii=[1, 2],
         mix_weights=[1, 1],
         window_functions=("fixed", "variable"),
-        window_orientations=['directional', 'directional'],
+        window_orientations=["directional", "directional"],
         n_iter=2,
     )
     assert (

--- a/vectorizers/token_cooccurrence_vectorizer.py
+++ b/vectorizers/token_cooccurrence_vectorizer.py
@@ -22,7 +22,7 @@ from .utils import (
     str_to_bytes,
     pair_to_tuple,
     make_tuple_converter,
-    dirichlet_process_normalize
+    dirichlet_process_normalize,
 )
 
 from .coo_utils import (
@@ -30,7 +30,7 @@ from .coo_utils import (
     coo_sum_duplicates,
     CooArray,
     merge_all_sum_duplicates,
-    set_array_size
+    set_array_size,
 )
 
 import numpy as np
@@ -390,6 +390,7 @@ def sequence_multi_skip_grams(
         [coo.val[: coo.ind[0]] for coo in coo_list],
     )
 
+
 def multi_token_cooccurrence_matrix(
     token_sequences,
     n_unique_tokens,
@@ -526,7 +527,6 @@ def multi_token_cooccurrence_matrix(
         cooccurrence_matrix.data[cooccurrence_matrix.data < epsilon] = 0
         cooccurrence_matrix.eliminate_zeros()
 
-
     # Do the EM
     n_chunks = (len(token_sequences) // chunk_size) + 1
 
@@ -554,7 +554,6 @@ def multi_token_cooccurrence_matrix(
         cooccurrence_matrix = normalizer(cooccurrence_matrix, axis=0, norm="l1").tocsr()
         cooccurrence_matrix.data[cooccurrence_matrix.data < epsilon] = 0
         cooccurrence_matrix.eliminate_zeros()
-
 
     return cooccurrence_matrix.tocsr()
 
@@ -1443,7 +1442,14 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
 
         return cooccurrences_
 
-    def reduce_dimension(self, dimension=150, algorithm="arpack", n_iter=10, row_norm='frequentist', power=0.25):
+    def reduce_dimension(
+        self,
+        dimension=150,
+        algorithm="arpack",
+        n_iter=10,
+        row_norm="frequentist",
+        power=0.25,
+    ):
         check_is_fitted(self, ["column_label_dictionary_"])
         if row_norm == "Bayesian":
             row_normalize = dirichlet_process_normalize
@@ -1451,8 +1457,12 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
             row_normalize = normalize
 
         if self.n_iter < 1:
-            self.reduced_matrix_ = self._normalize(self.cooccurrences_, axis=0, norm="l1")
-            self.reduced_matrix_ = row_normalize(self.reduced_matrix_, axis=1, norm="l1")
+            self.reduced_matrix_ = self._normalize(
+                self.cooccurrences_, axis=0, norm="l1"
+            )
+            self.reduced_matrix_ = row_normalize(
+                self.reduced_matrix_, axis=1, norm="l1"
+            )
         else:
             self.reduced_matrix_ = row_normalize(self.cooccurrences_, axis=1, norm="l1")
 

--- a/vectorizers/utils.py
+++ b/vectorizers/utils.py
@@ -10,7 +10,45 @@ from collections import Counter
 import re
 from warnings import warn
 from numba.np.unsafe.ndarray import to_fixed_tuple
+from scipy.special import digamma
 
+@numba.vectorize()
+def digamma(x):
+    if x <= 0:
+        return -np.inf
+    result = 0.0;
+    for i in range(x,7):
+        result -= 1 / x
+        x +=1
+    x -= 0.5
+    xx = 1.0 / x
+    xx2 = xx * xx
+    xx4 = xx2 * xx2
+    result += np.log(x) + (1.0 / 24.0) * xx2 - (7.0 / 960.0) * xx4 + (
+        (31.0 / 8064.0) * xx4 * xx2 - (127.0 / 30720.0) * xx4 * xx4)
+    return result
+
+@numba.njit()
+def dp_normalize(indptr, data, sums):
+    data = digamma(data)
+    sums = digamma(sums)
+    for i, this_sum in enumerate(sums):
+        for j in range(indptr[i], indptr[i+1]):
+            data[j] = np.exp(data[j]-this_sum)
+    return data
+
+def dirichlet_process_normalize(X, axis = 0, norm = 'l1'):
+    sums = np.array(X.sum(axis=axis)).flatten()
+    if axis == 0:
+        X = X.tocsc()
+        new_data = dp_normalize(X.indptr, X.data, sums)
+        X.data = new_data
+        return X.tocsr()
+    else:
+        X = X.tocsr()
+        new_data = dp_normalize(X.indptr, X.data, sums)
+        X.data = new_data
+        return X.tocsr()
 
 @numba.njit(nogil=True)
 def pair_to_tuple(pair):

--- a/vectorizers/utils.py
+++ b/vectorizers/utils.py
@@ -12,32 +12,39 @@ from warnings import warn
 from numba.np.unsafe.ndarray import to_fixed_tuple
 from scipy.special import digamma
 
+
 @numba.vectorize()
 def digamma(x):
     if x <= 0:
         return -np.inf
-    result = 0.0;
-    for i in range(x,7):
+    result = 0.0
+    for i in range(x, 7):
         result -= 1 / x
-        x +=1
+        x += 1
     x -= 0.5
     xx = 1.0 / x
     xx2 = xx * xx
     xx4 = xx2 * xx2
-    result += np.log(x) + (1.0 / 24.0) * xx2 - (7.0 / 960.0) * xx4 + (
-        (31.0 / 8064.0) * xx4 * xx2 - (127.0 / 30720.0) * xx4 * xx4)
+    result += (
+        np.log(x)
+        + (1.0 / 24.0) * xx2
+        - (7.0 / 960.0) * xx4
+        + ((31.0 / 8064.0) * xx4 * xx2 - (127.0 / 30720.0) * xx4 * xx4)
+    )
     return result
+
 
 @numba.njit()
 def dp_normalize(indptr, data, sums):
     data = digamma(data)
     sums = digamma(sums)
     for i, this_sum in enumerate(sums):
-        for j in range(indptr[i], indptr[i+1]):
-            data[j] = np.exp(data[j]-this_sum)
+        for j in range(indptr[i], indptr[i + 1]):
+            data[j] = np.exp(data[j] - this_sum)
     return data
 
-def dirichlet_process_normalize(X, axis = 0, norm = 'l1'):
+
+def dirichlet_process_normalize(X, axis=0, norm="l1"):
     sums = np.array(X.sum(axis=axis)).flatten()
     if axis == 0:
         X = X.tocsc()
@@ -49,6 +56,7 @@ def dirichlet_process_normalize(X, axis = 0, norm = 'l1'):
         new_data = dp_normalize(X.indptr, X.data, sums)
         X.data = new_data
         return X.tocsr()
+
 
 @numba.njit(nogil=True)
 def pair_to_tuple(pair):
@@ -201,7 +209,7 @@ def validate_homogeneous_token_types(data):
 
 
 def gmm_component_likelihood(
-        component_mean: np.ndarray, component_covar: np.ndarray, diagram: np.ndarray
+    component_mean: np.ndarray, component_covar: np.ndarray, diagram: np.ndarray
 ) -> np.ndarray:
     """Generate the vector of likelihoods of observing points in a diagram
     for a single gmm components (i.e. a single Gaussian). That is, evaluate
@@ -283,7 +291,7 @@ def mat_sqrt(mat: np.ndarray) -> np.ndarray:
 
 @numba.njit()
 def wasserstein2_gaussian(
-        m1: np.ndarray, C1: np.ndarray, m2: np.ndarray, C2: np.ndarray
+    m1: np.ndarray, C1: np.ndarray, m2: np.ndarray, C2: np.ndarray
 ) -> float:
     """Compute the Wasserstein_2 distance between two 2D Gaussians. This can be
     computed via the closed form formula:
@@ -320,7 +328,7 @@ def wasserstein2_gaussian(
 
 @numba.njit()
 def pairwise_gaussian_ground_distance(
-        means: np.ndarray, covariances: np.ndarray
+    means: np.ndarray, covariances: np.ndarray
 ) -> np.ndarray:
     """Compute pairwise distances between a list of Gaussians. This can be
     used as the ground distance for an earth-mover distance computation on
@@ -393,7 +401,8 @@ def procrustes_align(e1, e2, scale_to="both"):
         rescale_factor = np.sqrt(e1_scale_factor * e2_scale_factor)
     else:
         raise ValueError(
-            f"Invalid value {scale_to} for scale_to. scale_to should be one of 'first', 'second', or 'both'")
+            f"Invalid value {scale_to} for scale_to. scale_to should be one of 'first', 'second', or 'both'"
+        )
     e1_scaled = e1_shift / e1_scale_factor
     e2_scaled = e2_shift / e2_scale_factor
     covariance = e2_scaled.T @ e1_scaled


### PR DESCRIPTION
I added the Bayesian EM (it doesn't produce good results for words but it might be useful in other settings so it's there).  I also changed the coo construction to build bigger arrays if space is running low.  It works very well, causes very little hit to runtime but saves on memory and doesn't force examples to crash when you set too low of an array size but more memory is available. 