### PR TITLE
added document_context to TokenCooccurrenceVectorizer()

### DIFF
--- a/vectorizers/_window_kernels.py
+++ b/vectorizers/_window_kernels.py
@@ -10,8 +10,8 @@ from vectorizers.utils import flatten
 @numba.njit(nogil=True)
 def window_at_index(token_sequence, window_size, ind, reverse=False):
     if reverse:
-        return np.flip(token_sequence[max(ind - window_size, 0): ind])
-    return token_sequence[ind + 1: min(ind + window_size + 1, len(token_sequence))]
+        return np.flip(token_sequence[max(ind - window_size, 0) : ind])
+    return token_sequence[ind + 1 : min(ind + window_size + 1, len(token_sequence))]
 
 
 # Window width functions
@@ -19,10 +19,10 @@ def window_at_index(token_sequence, window_size, ind, reverse=False):
 
 @numba.njit(nogil=True)
 def variable_window_radii(
-        window_size,
-        token_frequency,
-        mask_index=None,
-        power=0.75,
+    window_size,
+    token_frequency,
+    mask_index=None,
+    power=0.75,
 ):
     radii = np.power(token_frequency, power - 1)
     radii /= np.sum(radii * token_frequency)
@@ -51,7 +51,7 @@ def flat_kernel(window, mask_index=None, normalize=False, offset=0):
     result = np.ones(len(window), dtype=np.float64)
     if mask_index is not None:
         result[window == mask_index] = 0.0
-    result[0: min(offset, len(result))] = 0
+    result[0 : min(offset, len(result))] = 0
     if normalize:
         temp = result.sum()
         if temp > 0:
@@ -64,7 +64,7 @@ def harmonic_kernel(window, mask_index=None, normalize=False, offset=0):
     result = 1.0 / np.arange(1, len(window) + 1)
     if mask_index is not None:
         result[window == mask_index] = 0.0
-    result[0: min(offset, len(result))] = 0
+    result[0 : min(offset, len(result))] = 0
     if normalize:
         temp = result.sum()
         if temp > 0:
@@ -74,17 +74,17 @@ def harmonic_kernel(window, mask_index=None, normalize=False, offset=0):
 
 @numba.njit(nogil=True)
 def geometric_kernel(
-        window,
-        mask_index=None,
-        normalize=False,
-        offset=0,
-        power=0.9,
+    window,
+    mask_index=None,
+    normalize=False,
+    offset=0,
+    power=0.9,
 ):
     result = power ** np.arange(0, len(window))
 
     if mask_index is not None:
         result[window == mask_index] = 0.0
-    result[0: min(offset, len(result))] = 0
+    result[0 : min(offset, len(result))] = 0
     if normalize:
         temp = result.sum()
         if temp > 0:
@@ -94,10 +94,10 @@ def geometric_kernel(
 
 @numba.njit(nogil=True)
 def update_kernel(
-        window,
-        kernel,
-        mask_index,
-        normalize,
+    window,
+    kernel,
+    mask_index,
+    normalize,
 ):
     result = kernel[: len(window)].astype(np.float64)
     if mask_index is not None:
@@ -107,38 +107,6 @@ def update_kernel(
         if temp > 0:
             result /= temp
     return result
-
-#@numba.njit(nogil=True)
-#def flatten_doc_window(doc_window):
-#    []
-
-# @numba.njit(nogil=True)
-def document_contexts(
-        doc_window,
-        target_index,
-        kernel_array,
-        kernel_masks,
-        kernel_normalize,
-):
-    #This can't be numba
-    #window_result = flatten(doc_window)
-    window_result = [x for window in doc_window for x in window]
-    kernel_result = np.zeros(len(window_result))
-    ind = 0
-    for d_i, doc in enumerate(doc_window):
-        kernel_result[ind: ind + len(doc)] = np.repeat(kernel_array[np.abs(d_i)], len(doc))
-        ind += len(doc)
-    kernel_result[target_index] = 0
-    if kernel_masks is not None:
-        print("Kernel masks are not implemented")
-#    if kernel_masks is not None:
-#        window_result[window_result == kernel_masks] = 0
-    if kernel_normalize:
-        temp = kernel_result.sum()
-        if temp > 0:
-            kernel_result /= temp
-
-    return window_result, kernel_result
 
 
 # Parameter lists

--- a/vectorizers/_window_kernels.py
+++ b/vectorizers/_window_kernels.py
@@ -108,24 +108,31 @@ def update_kernel(
             result /= temp
     return result
 
+#@numba.njit(nogil=True)
+#def flatten_doc_window(doc_window):
+#    []
 
 # @numba.njit(nogil=True)
 def document_contexts(
         doc_window,
-        target_doc,
+        target_index,
         kernel_array,
         kernel_masks,
         kernel_normalize,
 ):
-    window_result = flatten(doc_window)
-    kernel_result = np.zeros_like(window_result)
+    #This can't be numba
+    #window_result = flatten(doc_window)
+    window_result = [x for window in doc_window for x in window]
+    kernel_result = np.zeros(len(window_result))
     ind = 0
     for d_i, doc in enumerate(doc_window):
-        kernel_result[ind: ind + len(doc)] = np.repeat(kernel_array[np.abs(d_i - target_doc)], len(doc))
+        kernel_result[ind: ind + len(doc)] = np.repeat(kernel_array[np.abs(d_i)], len(doc))
         ind += len(doc)
-
+    kernel_result[target_index] = 0
     if kernel_masks is not None:
-        window_result[window_result == kernel_masks] = 0
+        print("Kernel masks are not implemented")
+#    if kernel_masks is not None:
+#        window_result[window_result == kernel_masks] = 0
     if kernel_normalize:
         temp = kernel_result.sum()
         if temp > 0:

--- a/vectorizers/coo_utils.py
+++ b/vectorizers/coo_utils.py
@@ -109,7 +109,7 @@ def merge_all_sum_duplicates(coo):
     merge_sum_duplicates(coo)
 
 
-# @numba.njit(nogil=True)
+@numba.njit(nogil=True)
 def coo_sum_duplicates(coo, kind):
     upper_lim = coo.ind[0]
     lower_lim = np.abs(coo.min[0])

--- a/vectorizers/coo_utils.py
+++ b/vectorizers/coo_utils.py
@@ -95,7 +95,7 @@ def merge_all_sum_duplicates(coo):
     merge_sum_duplicates(coo)
 
 
-@numba.njit(nogil=True)
+# @numba.njit(nogil=True)
 def coo_sum_duplicates(coo, kind):
     upper_lim = coo.ind[0]
     lower_lim = np.abs(coo.min[0])

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -567,6 +567,13 @@ def test_cooccurrence_vectorizer_wide_transform():
         == vectorizer_a.transform(token_data).nnz
     )
 
+def test_set_sequence_token_cooccurrence():
+    vectorizer_a = TokenCooccurrenceVectorizer(document_context=True)
+    assert (
+        vectorizer_a.fit_transform(multi_token_cooccurrence_matrix).nnz
+        == vectorizer_a.transform(multi_token_cooccurrence_matrix).nnz
+    )
+
 
 @pytest.mark.parametrize("kernel_function", ["harmonic", "flat", "geometric"])
 def test_token_cooccurrence_vectorizer_offset(kernel_function):

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -567,12 +567,26 @@ def test_cooccurrence_vectorizer_wide_transform():
         == vectorizer_a.transform(token_data).nnz
     )
 
-def test_set_sequence_token_cooccurrence():
-    vectorizer_a = TokenCooccurrenceVectorizer(document_context=True)
-    assert (
-        vectorizer_a.fit_transform(multi_token_cooccurrence_matrix).nnz
-        == vectorizer_a.transform(multi_token_cooccurrence_matrix).nnz
+def test_multi_label_token_cooccurrence():
+    vectorizer_a = TokenCooccurrenceVectorizer(
+        document_context=True,
+        window_radii=[1,2],
+        window_functions=['fixed','fixed'],
+        kernel_functions=['flat','flat'],
+        window_orientations=['before','before'],
+        normalize_windows=False,
+        coo_max_memory='1G'
     )
+
+    print(vectorizer_a.fit_transform(text_token_data_permutation).todense())
+    print(text_token_data_permutation)
+    print(vectorizer_a.token_label_dictionary_)
+    print(vectorizer_a.column_label_dictionary_)
+    assert (
+        vectorizer_a.fit_transform(text_token_data_permutation).nnz
+        == vectorizer_a.transform(text_token_data_permutation).nnz
+    )
+    assert (0==1)
 
 
 @pytest.mark.parametrize("kernel_function", ["harmonic", "flat", "geometric"])

--- a/vectorizers/utils.py
+++ b/vectorizers/utils.py
@@ -77,6 +77,7 @@ def flatten(list_of_seq):
         return list_of_seq
 
 
+
 def sparse_collapse(matrix, labels, sparse=True):
     """
     Groups the rows and columns of a matrix by the the labels array.


### PR DESCRIPTION
This allows contexts to range over documents.  This is quite useful when dealing with a sequence of multilabelled tokens.  We treat a multilabelled token as a document and build our contexts across those.