### PR TITLE
Change default normalization in TCV

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -314,4 +314,5 @@ sphinx_gallery_conf = {
 
 def setup(app):
     # a copy button to copy snippet of code from the documentation
-    app.add_javascript('js/copybutton.js')
+    # app.add_javascript('js/copybutton.js')
+    pass

--- a/vectorizers/token_cooccurrence_vectorizer.py
+++ b/vectorizers/token_cooccurrence_vectorizer.py
@@ -1118,7 +1118,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
     epsilon: float32 (optional default = 0)
         Sets values in the cooccurrence matrix (after l_1 normalizing the columns) less than epsilon to zero
 
-    normalization: str ("Bayesian" or "frequentist")
+    normalization: str ("bayesian" or "frequentist")
         Sets the feature normalization to be the frequentist L_1 norm or the Bayesian (Dirichlet Process) normalization
 
     coo_max_memory: str (optional, default = "0.5 GiB")
@@ -1158,7 +1158,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
         normalize_windows=True,
         n_iter=0,
         epsilon=0,
-        normalization="Bayesian",
+        normalization="frequentist",
         coo_max_memory="0.5 GiB",
         document_context=False,
     ):
@@ -1320,7 +1320,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
         assert len(self._kernel_functions) == self._n_wide
         assert len(self._kernel_args) == self._n_wide
 
-        if self.normalization == "Bayesian":
+        if self.normalization == "bayesian":
             self._normalize = dirichlet_process_normalize
         else:
             self._normalize = normalize
@@ -1649,7 +1649,7 @@ class TokenCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
         power=0.25,
     ):
         check_is_fitted(self, ["column_label_dictionary_"])
-        if row_norm == "Bayesian":
+        if row_norm == "bayesian":
             row_normalize = dirichlet_process_normalize
         else:
             row_normalize = normalize


### PR DESCRIPTION
The default normalization was "Bayesian" which performed less well. This will change it to "frequentist" as well as changing the option "Bayesian" to "bayesian" to match the other string params which are all uncapitalised.

Finally a minor fix to the sphinx build stuff was added.