### PR TITLE
Count feature compressor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             conda update --yes --quiet conda
             conda create -n testenv --yes --quiet python=3
             source activate testenv
-            conda install --yes pip numpy scipy scikit-learn pandas numba matplotlib sphinx sphinx_rtd_theme numpydoc pillow
+            conda install --yes pip numpy scipy scikit-learn pandas numba matplotlib sphinx sphinx_rtd_theme numpydoc pillow dask
             pip install pynndescent
             pip install sphinx-gallery
             pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ install:
   - source activate testenv
   - |
       if [ $SKLEARN_VERSION = "nightly" ]; then
-          conda install --yes numpy==$NUMPY_VERSION scipy==$SCIPY_VERSION cython nose pytest pytest-cov
+          conda install --yes numpy==$NUMPY_VERSION scipy==$SCIPY_VERSION cython nose pytest pytest-cov dask
           # install nightly wheels
           pip install --pre -f https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
       else
-          conda install --yes numpy==$NUMPY_VERSION scipy==$SCIPY_VERSION scikit-learn==$SKLEARN_VERSION cython nose pytest pytest-cov
+          conda install --yes numpy==$NUMPY_VERSION scipy==$SCIPY_VERSION scikit-learn==$SKLEARN_VERSION cython nose pytest pytest-cov dask
       fi
   - conda install --yes pandas numba
   - pip install pynndescent

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
   # install the dependencies
   - "conda install --yes pip numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% nose pytest pytest-cov"
-  - conda install --yes numba pandas
+  - conda install --yes numba pandas dask
   - pip install pynndescent
   - pip install codecov
   - pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ scipy
 scikit-learn
 numba
 pandas
+dask
 pynndescent>=0.5

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ URL = 'https://github.com/TutteInstitute/vectorizers'
 LICENSE = 'new BSD'
 DOWNLOAD_URL = 'https://github.com/TutteInstitute/vectorizers'
 VERSION = __version__
-INSTALL_REQUIRES = ['numpy', 'scipy', 'scikit-learn', 'numba', 'pynndescent']
+INSTALL_REQUIRES = ['numpy', 'scipy', 'scikit-learn', 'numba', 'pynndescent', 'dask']
 CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Intended Audience :: Developers',
                'License :: OSI Approved',

--- a/vectorizers/tests/test_transformers.py
+++ b/vectorizers/tests/test_transformers.py
@@ -216,8 +216,9 @@ def test_iw_transformer_zero_row(prior_strength, approx_prior):
     assert np.allclose(result.toarray(), transform.toarray())
 
 
-def test_count_feature_compression_basic():
-    cfc = CountFeatureCompressionTransformer(n_components=2)
+@pytest.mark.parametrize("algorithm", ["randomized", "arpack"])
+def test_count_feature_compression_basic(algorithm):
+    cfc = CountFeatureCompressionTransformer(n_components=2, algorithm=algorithm)
     result = cfc.fit_transform(test_matrix)
     transform = cfc.transform(test_matrix)
     assert np.allclose(result, transform)
@@ -234,3 +235,7 @@ def test_count_feature_compression_bad_input():
 
     with pytest.raises(ValueError):
         result = cfc.fit_transform(-test_matrix.toarray())
+
+    cfc = CountFeatureCompressionTransformer(n_components=2, algorithm="bad_value")
+    with pytest.raises(ValueError):
+        result = cfc.fit_transform(test_matrix)

--- a/vectorizers/tests/test_transformers.py
+++ b/vectorizers/tests/test_transformers.py
@@ -4,6 +4,7 @@ from vectorizers.transformers import (
     RemoveEffectsTransformer,
     InformationWeightTransformer,
     CategoricalColumnTransformer,
+    CountFeatureCompressionTransformer,
 )
 import numpy as np
 import scipy.sparse
@@ -213,3 +214,23 @@ def test_iw_transformer_zero_row(prior_strength, approx_prior):
     result = IWT.fit_transform(test_matrix_zero_row)
     transform = IWT.transform(test_matrix_zero_row)
     assert np.allclose(result.toarray(), transform.toarray())
+
+
+def test_count_feature_compression_basic():
+    cfc = CountFeatureCompressionTransformer(n_components=2)
+    result = cfc.fit_transform(test_matrix)
+    transform = cfc.transform(test_matrix)
+    assert np.allclose(result, transform)
+
+def test_count_feature_compression_warns():
+    cfc = CountFeatureCompressionTransformer(n_components=5)
+    with pytest.warns(UserWarning):
+        result = cfc.fit_transform(test_matrix)
+
+def test_count_feature_compression_bad_input():
+    cfc = CountFeatureCompressionTransformer(n_components=2)
+    with pytest.raises(ValueError):
+        result = cfc.fit_transform(-test_matrix)
+
+    with pytest.raises(ValueError):
+        result = cfc.fit_transform(-test_matrix.toarray())

--- a/vectorizers/transformers.py
+++ b/vectorizers/transformers.py
@@ -5,6 +5,9 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 from sklearn.preprocessing import normalize
 import scipy.sparse
+from sklearn.utils.extmath import randomized_svd, svd_flip
+from scipy.sparse.linalg import svds
+
 
 from warnings import warn
 
@@ -663,3 +666,126 @@ class CategoricalColumnTransformer(BaseEstimator, TransformerMixin):
     def fit(self, X, y=None, **fit_params):
         self.fit_transform(X, y, **fit_params)
         return self
+
+
+class CountFeatureCompressionTransformer(BaseEstimator, TransformerMixin):
+    """Large sparse high dimensional matrices of count based, or strictly
+    non-negative features are common. This transformer provides a simple
+    but often very effective dimension reduction approach to provide a
+    dense representation of the data that is amenable to cosine based distance
+    measures.
+
+    Parameters
+    ----------
+    n_components: int (optional, default=128)
+        The number of dimensions to use for the dense reduced representation.
+
+    n_iter: int (optional, default=7)
+        If using the ``"randomized"`` algorithm for SVD then use this number of
+        iterations for estimate the SVD.
+
+    algorithm: string (optional, default="randomized")
+        The algorithm to use internally for the SVD step. Should be one of
+            * "arpack"
+            * "randomized"
+    """
+
+    def __init__(self, n_components=128, n_iter=7, algorithm="randomized"):
+        self.n_components = n_components
+        self.n_iter = n_iter
+        self.algorithm = algorithm
+
+    def fit_transform(self, X, y=None, **fit_params):
+        """
+        Given a dataset of count based features (i.e. strictly positive)
+        perform feature compression / dimension reduction to provide
+        a dataset with ``self.n_components`` dimensions suitable for
+        measuring distances using cosine distance.
+
+        Parameters
+        ----------
+        X: ndarray or sparse matrix of shape (n_samples, n_features)
+            The input data to be transformed.
+
+        Returns
+        -------
+        result: ndarray of shape (n_samples, n_components)
+            The dimension reduced representation of the input.
+        """
+        # Handle too large an n_components value somewhat gracefully
+        if self.n_components >= X.shape[1]:
+            warn(
+                f"Warning: n_components is {self.n_components} but input has only {X.shape[1]} features!"
+                f"No compression will be performed."
+            )
+            self.components_ = np.eye(X.shape[1])
+            self.component_scaling_ = np.ones(X.shape[1])
+            return X
+
+        if scipy.sparse.isspmatrix(X):
+            if np.any(X.data < 0.0):
+                raise ValueError("All entries in input most be non-negative!")
+        else:
+            if np.any(X < 0.0):
+                raise ValueError("All entries in input most be non-negative!")
+
+        normed_data = normalize(X)
+        rescaled_data = np.sqrt(normed_data)
+        if self.algorithm == "arpack":
+            u, s, v = svds(rescaled_data, k=self.n_components)
+        elif self.algorithm == "randomized":
+            u, s, v = randomized_svd(
+                rescaled_data, n_components=self.n_components, n_iter=self.n_iter
+            )
+        else:
+            raise ValueError("algorithm should be one of 'arpack' or 'randomized'")
+
+        u, v = svd_flip(u, v)
+        self.component_scaling_ = np.sqrt(s)
+        self.components_ = v
+        self.metric_ = "cosine"
+
+        result = u * self.component_scaling_
+
+        return result
+
+    def fit(self, X, y=None, **fit_params):
+        """
+        Given a dataset of count based features (i.e. strictly positive)
+        learn a feature compression / dimension reduction to provide
+        a dataset with ``self.n_components`` dimensions suitable for
+        measuring distances using cosine distance.
+
+        Parameters
+        ----------
+        X: ndarray or sparse matrix of shape (n_samples, n_features)
+            The input data to be transformed.
+        """
+        self.fit_transform(self, X, y, **fit_params)
+        return self
+
+    def transform(self, X, y=None):
+        """
+        Given a dataset of count based features (i.e. strictly positive)
+        perform the learned feature compression / dimension reduction.
+
+        Parameters
+        ----------
+        X: ndarray or sparse matrix of shape (n_samples, n_features)
+            The input data to be transformed.
+
+        Returns
+        -------
+        result: ndarray of shape (n_samples, n_components)
+            The dimension reduced representation of the input.
+        """
+        check_is_fitted(
+            self,
+            ["components_", "component_scaling_"],
+        )
+        normed_data = normalize(X)
+        rescaled_data = np.sqrt(normed_data)
+
+        result = (rescaled_data @ self.components_.T) / self.component_scaling_
+
+        return result

--- a/vectorizers/transformers.py
+++ b/vectorizers/transformers.py
@@ -2,7 +2,12 @@ import numba
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
+from sklearn.utils.validation import (
+    check_X_y,
+    check_array,
+    check_is_fitted,
+    check_random_state,
+)
 from sklearn.preprocessing import normalize
 import scipy.sparse
 from sklearn.utils.extmath import randomized_svd, svd_flip
@@ -688,12 +693,19 @@ class CountFeatureCompressionTransformer(BaseEstimator, TransformerMixin):
         The algorithm to use internally for the SVD step. Should be one of
             * "arpack"
             * "randomized"
+
+    random_state: int, np.random_state or None (optional, default=None)
+        If using the ``"randomized"`` algorithm for SVD then use this as the
+        random state (or random seed).
     """
 
-    def __init__(self, n_components=128, n_iter=7, algorithm="randomized"):
+    def __init__(
+        self, n_components=128, n_iter=7, algorithm="randomized", random_state=None
+    ):
         self.n_components = n_components
         self.n_iter = n_iter
         self.algorithm = algorithm
+        self.random_state = random_state
 
     def fit_transform(self, X, y=None, **fit_params):
         """
@@ -734,8 +746,12 @@ class CountFeatureCompressionTransformer(BaseEstimator, TransformerMixin):
         if self.algorithm == "arpack":
             u, s, v = svds(rescaled_data, k=self.n_components)
         elif self.algorithm == "randomized":
+            random_state = check_random_state(self.random_state)
             u, s, v = randomized_svd(
-                rescaled_data, n_components=self.n_components, n_iter=self.n_iter
+                rescaled_data,
+                n_components=self.n_components,
+                n_iter=self.n_iter,
+                random_state=random_state,
             )
         else:
             raise ValueError("algorithm should be one of 'arpack' or 'randomized'")


### PR DESCRIPTION
It turns our that our data-prep tricks prior and after SVDs for count-based data are generically useful. I tried applying them to info-weighted bag-of-words on 20-newsgroups instead of just a straight SVD and ...

![image](https://user-images.githubusercontent.com/11962885/127711226-8ee894b0-0310-49b8-aa0b-9dc4c6f3fea1.png)

I decided this is going to be too generically useful not to turn into a standard transformer. In due course we can potentially use this as part of a pipeline for word vectors instead of the ``reduce_dimension`` method we have now.