### PR TITLE
Take iisignature off of the list of direct deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,7 @@ steps:
     python -m pip install --upgrade pip
     pip install numpy
     pip install -r requirements.txt
+    pip install iisignature
   displayName: 'Install dependencies'
 
 - script: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pandas
 dask
 pynndescent>=0.5
 pomegranate
-iisignature

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ URL = 'https://github.com/TutteInstitute/vectorizers'
 LICENSE = 'new BSD'
 DOWNLOAD_URL = 'https://github.com/TutteInstitute/vectorizers'
 VERSION = __version__
-INSTALL_REQUIRES = ['numpy', 'scipy', 'scikit-learn', 'numba', 'pynndescent', 'dask', 'iisignature']
+INSTALL_REQUIRES = ['numpy', 'pandas', 'scipy', 'scikit-learn', 'numba', 'pynndescent', 'dask']
 CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Intended Audience :: Developers',
                'License :: OSI Approved',

--- a/vectorizers/signature_vectorizer.py
+++ b/vectorizers/signature_vectorizer.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-import iisignature
+#import iisignature
 
 NUMPY_SHAPE_ERROR_MSG = """
 Error: SignatureVectorizer expects numpy arrays to be of shape (num_samples x path_len x path_dim).
@@ -42,6 +42,26 @@ class SignatureVectorizer(BaseEstimator, TransformerMixin):
     def __init__(
         self, truncation_level: int = 2, log: bool = False, basepoint: bool = False
     ):
+        try:
+            import iisignature
+        except ImportError as err:
+            from textwrap import dedent
+            err.msg += dedent(
+                """
+
+                A small bug with the install script of the iisignature makes it
+                impossible to install into an environment where its Numpy dependency
+                has not yet been installed. Thus, the Vectorizers library does not
+                make it an explicit dependency. However, you may install this package
+                yourself into this environment now, by running the command
+
+                pip install iisignature
+
+                The problem has been reported to the maintainers of iisignature, and
+                this inconvenience will disappear in future releases.
+                """
+            )
+            raise
 
         assert (
             type(truncation_level) is int

--- a/vectorizers/signature_vectorizer.py
+++ b/vectorizers/signature_vectorizer.py
@@ -43,7 +43,9 @@ class SignatureVectorizer(BaseEstimator, TransformerMixin):
         self, truncation_level: int = 2, log: bool = False, basepoint: bool = False
     ):
         try:
-            import iisignature
+            global iisignature
+            import iisignature as ii
+            iisignature = ii
         except ImportError as err:
             from textwrap import dedent
             err.msg += dedent(


### PR DESCRIPTION
The iisignature package has a problem in its setup script. This patches things up until upstream fixes it.