### PR TITLE
BPE: contracting single-token string is no-op

### DIFF
--- a/vectorizers/mixed_gram_vectorizer.py
+++ b/vectorizers/mixed_gram_vectorizer.py
@@ -227,6 +227,8 @@ def contract_and_count_pairs(char_list, pair_to_contract, pair_counts, new_code=
     """
     skip_char = False
     len_char_list = len(char_list)
+    if len_char_list < 2:
+        return char_list, pair_counts
     last_char_added = -1
     new_char_list = np.zeros(len_char_list, dtype=np.int64)
     new_char_index = 0
@@ -478,6 +480,8 @@ def contract_pair(char_list, pair_to_contract, new_code=-1):
     """
     skip_char = False
     len_char_list = len(char_list)
+    if len_char_list < 2:
+        return char_list
     new_char_list = np.zeros(len_char_list, dtype=np.int64)
     new_char_index = 0
 

--- a/vectorizers/tests/test_bpe.py
+++ b/vectorizers/tests/test_bpe.py
@@ -103,3 +103,25 @@ def test_bpe_max_char_code_limits(name, max_expected):
 def test_bpe_max_char_code_limit_wrong():
     with pytest.raises(ValueError):
         BytePairEncodingVectorizer(max_char_code="utf8").fit(raw_string_data)
+
+
+def test_bpe_contract_pair_single_token_training():
+    seqs_tokens = BytePairEncodingVectorizer(return_type="tokens").fit_transform([
+        "asdfqwerty",
+        "asdf",
+        "qwzxasdfcv"
+    ])
+    assert [
+        ["asdf", "qw", "e", "r", "t", "y"],
+        ["asdf"],
+        ["qw", "z", "x", "asdf", "c", "v"],
+    ] == seqs_tokens
+
+
+def test_bpe_contract_pair_single_token_inference():
+    bpe = BytePairEncodingVectorizer(return_type="tokens").fit([
+        "asdfqwerty",
+        "asdfg",
+        "qwzxasdfcv",
+    ])
+    assert [["asdf"]] == bpe.transform(["asdf"])


### PR DESCRIPTION
Without this fix, functions contract_pair and contract_and_count_pairs fail to consider the case where a string has compressed down to a single token. Applying the usual processing to such a string results in the generation of an uninitialized empty string, which is wrong and leads to crashes (Numba bug).