### PR TITLE
Add validation to the parameters used to fit a Wasserstein vectorizer with LiL input method

### DIFF
--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -1148,50 +1148,6 @@ def test_wasserstein_based_vectorizer_bad_params(
         vectorizer.fit(distributions_data_generator, vectors=vectors_data_generator)
 
 
-# @pytest.mark.parametrize(
-#     "wasserstein_class",
-#     [WassersteinVectorizer, SinkhornVectorizer, ApproximateWassersteinVectorizer],
-# )
-# def test_wasserstein_based_vectorizer_bad_params(wasserstein_class):
-#     with pytest.raises(ValueError):
-#         vectorizer = wasserstein_class()
-#         vectorizer.fit(distributions_data)
-#
-#     with pytest.raises(ValueError):
-#         vectorizer = wasserstein_class()
-#         vectorizer.fit(mixed_token_data, vectors=vectors_data)
-#
-#     with pytest.raises(ValueError):
-#         vectorizer = wasserstein_class()
-#         vectorizer.fit(point_data, vectors=vectors_data)
-#
-#     distributions_data_generator = (x for x in distributions_data_list)
-#     vectors_data_generator = (x for x in vectors_data_list)
-#     with pytest.raises(ValueError):
-#         vectorizer = WassersteinVectorizer()
-#         vectorizer.fit(distributions_data_generator, vectors=vectors_data_generator)
-#
-#     distributions_data_generator = (x for x in distributions_data_list)
-#     vectors_data_generator = (x for x in vectors_data_list)
-#     with pytest.raises(ValueError):
-#         vectorizer = WassersteinVectorizer()
-#         vectorizer.fit(
-#             distributions_data_generator,
-#             vectors=vectors_data_generator,
-#             reference_vectors=np.random.random((10, vectors_data.shape[1])),
-#         )
-#
-#     distributions_data_generator = (x for x in distributions_data_list)
-#     vectors_data_generator = (x for x in vectors_data_list)
-#     with pytest.raises(ValueError):
-#         vectorizer = WassersteinVectorizer(reference_size=20)
-#         vectorizer.fit(
-#             distributions_data_generator,
-#             vectors=vectors_data_generator,
-#             reference_vectors=np.random.random((10, vectors_data.shape[1])),
-#         )
-
-
 @pytest.mark.parametrize("method", ["LOT_exact", "LOT_sinkhorn"])
 def test_wasserstein_based_vectorizer_bad_metrics(method):
     with pytest.raises(ValueError):

--- a/vectorizers/tests/test_common.py
+++ b/vectorizers/tests/test_common.py
@@ -1148,6 +1148,62 @@ def test_wasserstein_based_vectorizer_bad_params(
         vectorizer.fit(distributions_data_generator, vectors=vectors_data_generator)
 
 
+@pytest.mark.parametrize("seq_X", [list, tuple])
+@pytest.mark.parametrize("seq_vectors", [list, tuple])
+def test_wasserstein_lil_different_length_X_vectors(seq_X, seq_vectors):
+    with pytest.raises(ValueError):
+        WassersteinVectorizer(input_method="lil", method="LOT_exact").fit(
+            seq_X(np.array(a) for a in [[1., 1.], [1., 1., 1.], [1., 1., 1.]]),
+            vectors=seq_vectors([vectors_data[:2, :], vectors_data[2:2 + 3, :]])
+        )
+
+
+@pytest.mark.parametrize("seq_X", [list, tuple])
+@pytest.mark.parametrize("seq_vectors", [list, tuple])
+def test_wasserstein_lil_incoherent_X_vectors(seq_X, seq_vectors):
+    with pytest.raises(ValueError):
+        WassersteinVectorizer(input_method="lil", method="LOT_exact").fit(
+            seq_X(np.array(a) for a in [[1., 1.], [1., 1., 1.], [1., 1., 1.]]),
+            vectors=seq_vectors([
+                vectors_data[:2],
+                vectors_data[2:2 + 3],
+                vectors_data[5:5 + 4],
+            ])
+        )
+
+
+@pytest.mark.parametrize("seq_X", [list, tuple])
+@pytest.mark.parametrize("seq_vectors", [list, tuple])
+def test_wasserstein_lil_vectors_varying_size(seq_X, seq_vectors):
+    with pytest.raises(ValueError):
+        WassersteinVectorizer(input_method="lil", method="LOT_exact").fit(
+            seq_X(np.array(a) for a in [[1., 1.], [1., 1., 1.], [1., 1., 1.]]),
+            vectors=seq_vectors([
+                vectors_data[:2],
+                vectors_data[2:2 + 3],
+                np.hstack([vectors_data[5:5 + 3], np.zeros((3, 1))]),
+            ])
+        )
+
+
+@pytest.mark.parametrize("seq_X", [list, tuple])
+@pytest.mark.parametrize("seq_vectors", [list, tuple])
+def test_wasserstein_lil_weights_non_sequence(seq_X, seq_vectors):
+    with pytest.raises(ValueError):
+        WassersteinVectorizer(input_method="lil", method="LOT_exact").fit(
+            seq_X(np.array(a) for a in [
+                np.ones((2, 2)),
+                np.ones((3, 2)),
+                np.ones((3, 2)),
+            ]),
+            vectors=seq_vectors([
+                vectors_data[:2],
+                vectors_data[2:2 + 3],
+                vectors_data[5:5 + 3],
+            ])
+        )
+
+
 @pytest.mark.parametrize("method", ["LOT_exact", "LOT_sinkhorn"])
 def test_wasserstein_based_vectorizer_bad_metrics(method):
     with pytest.raises(ValueError):


### PR DESCRIPTION
This fixes some outstanding failing unit tests. The crux of the problem is that an issue that used to be raised as a `numba.TypingError` exception is now raised as a `TypeError`, and we didn't catch these. I took the opportunity to add a few more unit tests that break proper conventions of the list-of-lists input method of the Wasserstein vectorizer, and discovered deep breakages. I thus added earlier parameter validation with error messages that catch incoherent `X` and `vectors` arguments.