### PR TITLE
Fix pretty printing of TokenCooccurrenceVectorizer

### DIFF
--- a/vectorizers/base_cooccurrence_vectorizer.py
+++ b/vectorizers/base_cooccurrence_vectorizer.py
@@ -215,6 +215,7 @@ class BaseCooccurrenceVectorizer(BaseEstimator, TransformerMixin):
         self.epsilon = epsilon
         self.token_label_dictionary_ = {}
         self.token_index_dictionary_ = {}
+        self.coo_initial_memory = coo_initial_memory
         self.coo_initial_bytes = str_to_bytes(coo_initial_memory)
 
         # Set attributes


### PR DESCRIPTION
The pretty printing was failing because the human readable `coo_initial_memory` was expected but only used to set `coo_initial_bytes`.

Fixes https://github.com/TutteInstitute/vectorizers/issues/97