### PR TITLE
docs: fix typo in cyber example notebook

### DIFF
--- a/doc/token_cooccurrence_vectorizer_multi_labelled_cyber_example.ipynb
+++ b/doc/token_cooccurrence_vectorizer_multi_labelled_cyber_example.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "## Sequences of Multi-labelled data\n",
-    "Earlier we have examined the notion that documents can the thought of a sequence of tokens along with a mapping from a set of labels to these tokens.  Ideas like stemming and lemmatization are linguistic methods for applying different label mappings to these token sequences.  An example of this might be the sequence of tokens assocated with the sentence:\n",
+    "Earlier we have examined the notion that documents can be thought of as sequences of tokens along with a mapping from a set of labels to these tokens.  Ideas like stemming and lemmatization are linguistic methods for applying different label mappings to these token sequences.  An example of this might be the sequence of tokens assocated with the sentence:\n",
     "<pre>\"the cats sat in the cat box\"</pre>\n",
     "This can be decomposed into the sequence of tokens:\n",
     "<pre>[the, cats, sat, in, the, cat, box]</pre>\n",


### PR DESCRIPTION
Closes #148. Fixed the typo 'that documents can the thought of a sequence of tokens' -> 'that documents can be thought of as sequences of tokens' in the cyber example notebook.