### PR TITLE
Fix bugs in MultiSetCooccurrenceVectorizer skip-gram construction

### DIFF
--- a/vectorizers/multi_token_cooccurence_vectorizer.py
+++ b/vectorizers/multi_token_cooccurence_vectorizer.py
@@ -133,7 +133,7 @@ def numba_build_multi_skip_grams(
                         row = target_word
                         col = context + i * n_unique_tokens
                         key = col + array_mul * row
-                        coo_append(coo_data[i], (row, col, val, key))
+                        coo_data[i] = coo_append(coo_data[i], (row, col, val, key))
 
     for coo in coo_data:
         coo_sum_duplicates(coo)

--- a/vectorizers/multi_token_cooccurence_vectorizer.py
+++ b/vectorizers/multi_token_cooccurence_vectorizer.py
@@ -93,12 +93,12 @@ def numba_build_multi_skip_grams(
                 if not window_reversals[i]:
                     multi_window = token_sequences[
                         d_i : min(
-                            [len(token_sequences), d_i + window_size_array[i, 0] + 1]
+                            [len(token_sequences), d_i + window_size_array[i, target_word] + 1]
                         )
                     ]
                 else:
                     multi_window = token_sequences[
-                        max([0, d_i - window_size_array[i, 0]]) : d_i + 1
+                        max([0, d_i - window_size_array[i, target_word]]) : d_i + 1
                     ]
                     multi_window.reverse()
 
@@ -211,12 +211,12 @@ def numba_multi_em_cooccurrence_iteration(
                 if not window_reversals[i]:
                     multi_window = token_sequences[
                         d_i : min(
-                            [len(token_sequences), d_i + window_size_array[i, 0] + 1]
+                            [len(token_sequences), d_i + window_size_array[i, target_word] + 1]
                         )
                     ]
                 else:
                     multi_window = token_sequences[
-                        max([0, d_i - window_size_array[i, 0]]) : d_i + 1
+                        max([0, d_i - window_size_array[i, target_word]]) : d_i + 1
                     ]
                     multi_window.reverse()
 


### PR DESCRIPTION
This PR fixes two bugs in `MultiSetCooccurrenceVectorizer` that caused incorrect co-occurrence matrix construction.

## 1. Fix missing assignment from `coo_append`

In `numba_build_multi_skip_grams`, the result of `coo_append` was not assigned back:

```python
coo_append(coo_data[i], (row, col, val, key))
```

The `TokenCooccurrenceVectorizer` implementation correctly updates the buffer:

```python
coo_data[i] = coo_append(coo_data[i], (row, col, val, key))
```

Since `coo_append` returns the updated `CooArray`, the previous implementation could silently discard appended co-occurrence entries.

This caused the generated co-occurrence matrix to be incomplete.

## 2. Fix multiset window radius lookup

The multiset implementation used:

```python
window_size_array[i, 0]
```

when constructing the before/after multiset window.

This ignores the current target token and makes every token use the window size associated with vocabulary index `0`.

The token implementation uses:

```python
window_size_array[i, target_word]
```

so the multiset version should use the same target-dependent lookup:

```python
window_size_array[i, target_word]
```

This restores the intended behavior where each token can have its own window radius.